### PR TITLE
Update writePsrfits2FromHDF5.py for OVRO-LWA data

### DIFF
--- a/writePsrfits2FromHDF5.py
+++ b/writePsrfits2FromHDF5.py
@@ -242,9 +242,9 @@ def main(args):
         pfo.hdr.npol = nPols
         pfo.hdr.summed_polns = 1 if (not args.no_summing) else 0
         pfo.hdr.obs_mode = "SEARCH"
-        pfo.hdr.telescope = "LWA"
-        pfo.hdr.frontend = "LWA"
-        pfo.hdr.backend = "DRSpectrometer"
+        pfo.hdr.telescope = "OVRO-LWA"
+        pfo.hdr.frontend = "OVRO-LWA"
+        pfo.hdr.backend = "Beamformer"
         pfo.hdr.project_id = "Pulsar"
         pfo.hdr.ra_str = args.ra
         pfo.hdr.dec_str = args.dec

--- a/writePsrfits2FromHDF5.py
+++ b/writePsrfits2FromHDF5.py
@@ -256,7 +256,7 @@ def main(args):
         pfo.hdr.npol = nPols
         pfo.hdr.summed_polns = 1 if (not args.no_summing) else 0
         pfo.hdr.obs_mode = "SEARCH"
-        if station in ('ovro-lwa', 'ovrolwa', 'ovro'):
+        if station in ('ovro-lwa', 'ovrolwa'):
             pfo.hdr.telescope = "OVRO-LWA"
             pfo.hdr.frontend = "OVRO-LWA"
             pfo.hdr.backend = "Beamformer"

--- a/writePsrfits2FromHDF5.py
+++ b/writePsrfits2FromHDF5.py
@@ -256,7 +256,7 @@ def main(args):
         pfo.hdr.npol = nPols
         pfo.hdr.summed_polns = 1 if (not args.no_summing) else 0
         pfo.hdr.obs_mode = "SEARCH"
-        if station == 'ovro-lwa':
+        if station in ('ovro-lwa', 'ovrolwa', 'ovro'):
             pfo.hdr.telescope = "OVRO-LWA"
             pfo.hdr.frontend = "OVRO-LWA"
             pfo.hdr.backend = "Beamformer"

--- a/writePsrfits2FromHDF5.py
+++ b/writePsrfits2FromHDF5.py
@@ -148,11 +148,11 @@ def main(args):
     
     ## Date
     try:
-        beginATime = AstroTime(obs1['time'][0]['int'], obs1['time']['frac'],
+        beginATime = AstroTime(obs1['time'][0]['int'], obs1['time'][0]['frac'],
                                format=obs1['time'].attrs['format'],
                                scale=obs1['time'].attrs['scale'])
     except (KeyError, ValueError):
-        beginAtime = AstroTime(obs1['time'][0], format='unix', scale='utc')
+        beginATime = AstroTime(obs1['time'][0], format='unix', scale='utc')
     beginDate = beginATime.utc.datetime
     beginTime = beginDate
     mjd = beginATime.utc.mjd

--- a/writePsrfits2FromHDF5.py
+++ b/writePsrfits2FromHDF5.py
@@ -54,6 +54,11 @@ def main(args):
     if len(fh.keys()) != 1 or 'Observation1' not in fh:
         raise RuntimeError('Only HDF5 waterfall files with a single observation, labeled "Observation1", are supported')
         
+    try:
+        station = fh.attrs['StationName']
+    except KeyError:
+        station = 'lwa1'
+        
     obs1 = fh['Observation1']
     if args.source is None:
         try:
@@ -251,9 +256,14 @@ def main(args):
         pfo.hdr.npol = nPols
         pfo.hdr.summed_polns = 1 if (not args.no_summing) else 0
         pfo.hdr.obs_mode = "SEARCH"
-        pfo.hdr.telescope = "OVRO-LWA"
-        pfo.hdr.frontend = "OVRO-LWA"
-        pfo.hdr.backend = "Beamformer"
+        if station == 'ovro-lwa':
+            pfo.hdr.telescope = "OVRO-LWA"
+            pfo.hdr.frontend = "OVRO-LWA"
+            pfo.hdr.backend = "Beamformer"
+        else:
+            pfo.hdr.telescope = "LWA"
+            pfo.hdr.frontend = "LWA"
+            pfo.hdr.backend = "DRSpectrometer"
         pfo.hdr.project_id = "Pulsar"
         pfo.hdr.ra_str = args.ra
         pfo.hdr.dec_str = args.dec

--- a/writePsrfits2FromHDF5.py
+++ b/writePsrfits2FromHDF5.py
@@ -220,7 +220,7 @@ def main(args):
         OptimizeDataLevels = OptimizeDataLevels8Bit
         
     for t in range(1, 2+1):
-        if t == 2 and obs1Tuning2 is None:
+        if t == 2 and obs1tuning2 is None:
             continue
             
         ## Basic structure and bounds
@@ -387,7 +387,7 @@ def main(args):
         
         ## Write the spectra to the PSRFITS files
         for j,sp,bz,bs,wt in zip(range(2), (bdata1, bdata2), (bzero1, bzero2), (bscale1, bscale2), (weight1, weight2)):
-            if j == 1 and obs1Tuning2 is None:
+            if j == 1 and obs1tuning2 is None:
                 continue
                 
             ## Time

--- a/writePsrfits2FromHDF5.py
+++ b/writePsrfits2FromHDF5.py
@@ -144,7 +144,7 @@ def main(args):
     tInt = obs1.attrs['tInt']
     
     # Sub-integration block size
-    nsblk = 32
+    nsblk = args.nsblk
     
     ## Date
     try:
@@ -441,6 +441,8 @@ if __name__ == "__main__":
                         help='skip the specified number of seconds at the beginning of the file')
     parser.add_argument('-o', '--output', type=str, 
                         help='output file basename')
+    parser.add_argument('-b', '--nsblk', type=aph.positive_int, default=32,
+￼                        help='number of spetra per sub-block')
     parser.add_argument('-p', '--no-sk-flagging', action='store_true', 
                         help='disable on-the-fly SK flagging of RFI')
     parser.add_argument('-n', '--no-summing', action='store_true', 

--- a/writePsrfits2FromHDF5.py
+++ b/writePsrfits2FromHDF5.py
@@ -442,7 +442,7 @@ if __name__ == "__main__":
     parser.add_argument('-o', '--output', type=str, 
                         help='output file basename')
     parser.add_argument('-b', '--nsblk', type=aph.positive_int, default=32,
-￼                        help='number of spetra per sub-block')
+                        help='number of spetra per sub-block')
     parser.add_argument('-p', '--no-sk-flagging', action='store_true', 
                         help='disable on-the-fly SK flagging of RFI')
     parser.add_argument('-n', '--no-summing', action='store_true', 


### PR DESCRIPTION
This PR adds a catch to `writePsrfits2FromHDF5.py` that allows it to process power beam data from the OVRO-LWA.